### PR TITLE
Handle corner cases of empty and size one matrices.

### DIFF
--- a/gulinalg/src/gulinalg.c.src
+++ b/gulinalg/src/gulinalg.c.src
@@ -1895,8 +1895,14 @@ static void
 
     m = (fortran_int) dimensions[0];
     n = (fortran_int) dimensions[1];
-    if (m == 0 || n == 0)
-        return; /* output array will be empty, as one of its inner dimensions will be 0 */
+
+    /*
+     * Signature of matvec is (m,n),(n)->(m), i.e. if m = 0, output will
+     * be empty. However, if n = 0, output will be zero array of shape m.
+     */
+    if (m == 0) {
+        return;
+    }
 
     size_t sot = sizeof(@typ@);
 
@@ -1912,10 +1918,26 @@ static void
         }
 
         BEGIN_OUTER_LOOP_3
-            /* Acutal flattening happens here. */
+            if (n == 0) {
+                /*
+                 * If n = 0, each output matrix will be zero filled
+                 * array of shape m.
+                 */
+                memset(args[2], 0, m*sizeof(@typ@));
+            }
+
+            /* Actual flattening happens here. */
             @typ@ *A = linearize_@TYPE@_matrix(params.A, args[0], &a_in);
-            fortran_int incx = steps[2] / sot;
-            fortran_int incy = steps[3] / sot;
+
+            /*
+             * If size of a vector is 1 (or matrix is 1x1), gufunc won't
+             * step along that dimension. The stride will be 0 for that
+             * dimension.
+             * Refer: https://docs.scipy.org/doc/numpy-1.15.1/reference/ufuncs.html#broadcasting
+             * GEMV exepcts positive incx and incy, so set that to 1.
+             */
+            fortran_int incx = steps[2] != 0 ? steps[2] / sot : 1;
+            fortran_int incy = steps[3] != 0 ? steps[3] / sot : 1;
 
             /*
              * Invoke Fortran function GEMV.
@@ -1928,6 +1950,7 @@ static void
                           (void*)args[1], &incx,
                           (void*)&@zero@, // beta = 0, same as matrix_multiply.
                           (void*)args[2], &incy);
+
         END_OUTER_LOOP
 
         release_gemv_params(&params);
@@ -2016,8 +2039,16 @@ static void
 
         BEGIN_OUTER_LOOP_4
             linearize_@TYPE@_matrix(params.A, args[2], &a_in);
-            fortran_int incx = steps[0] / sot;
-            fortran_int incy = steps[1] / sot;
+
+            /*
+             * If size of a vector is 1 (or matrix is 1x1), gufunc won't
+             * step along that dimension. The stride will be 0 for that
+             * dimension.
+             * Refer: https://docs.scipy.org/doc/numpy-1.15.1/reference/ufuncs.html#broadcasting
+             * GER expects positive incx and incy, so set that to 1.
+             */
+            fortran_int incx = steps[0] != 0 ? steps[0] / sot : 1;
+            fortran_int incy = steps[1] != 0 ? steps[1] / sot : 1;
 
             /*
              * To get rank1 update, invoke ger_ for real numbers and _gerc/_geru
@@ -3263,6 +3294,13 @@ static void
     fortran_int m, n;
     m = (fortran_int) dimensions[0];
     n = (fortran_int) dimensions[1];
+    /*
+     * If m = 0, all output matrices will be empty and no need to
+     * zero initialize them.
+     */
+    if (m == 0) {
+        return;
+    }
 
     if (init_getrf_func(&params, m, n, steps, sizeof(@ftyp@)))
     {
@@ -3505,6 +3543,15 @@ static void
     INIT_OUTER_LOOP_3
     m = (fortran_int) dimensions[0];
     n = (fortran_int) dimensions[1];
+
+    /*
+     * If m = 0, all output matrices will be empty and no need to
+     * zero initialize them.
+     */
+    if (m == 0) {
+        return;
+    }
+
     min_m_n = m < n ? m : n;
     k = min_m_n;
 
@@ -5122,6 +5169,11 @@ static inline void @TYPE@_inv_triangular(char uplo,
     INIT_OUTER_LOOP_2
 
     n = (fortran_int)dimensions[0];
+    /* output array will be empty, as one of its inner dimensions will be 0 */
+    if (n == 0) {
+        return;
+    }
+
     if (init_@lapack_func@(&params, n)) {
         LINEARIZE_DATA_t a_in, r_out;
 
@@ -5269,6 +5321,11 @@ static void
 
     n = (fortran_int)dimensions[0];
     nrhs = ndim?(fortran_int)dimensions[1]:1;
+
+    /* output array will be empty, as one of its inner dimensions will be 0 */
+    if (n == 0) {
+        return;
+    }
 
     if (init_@lapack_func@(&params, n, nrhs)) {
         LINEARIZE_DATA_t a_in, b_in, r_out;

--- a/gulinalg/tests/test_decomposition.py
+++ b/gulinalg/tests/test_decomposition.py
@@ -3,9 +3,10 @@ Tests different implementations of decomposition functions.
 """
 
 from __future__ import print_function
-from unittest import TestCase
+from unittest import TestCase, skipIf
 import numpy as np
 from numpy.testing import run_module_suite, assert_allclose
+from pkg_resources import parse_version
 import gulinalg
 
 
@@ -25,7 +26,49 @@ class TestLU(TestCase):
         p, l, u = gulinalg.lu(a)
         assert_allclose(np.dot(np.dot(p, l), u), a)
 
-    def test_lu_size_1_matrix(self):
+    @skipIf(parse_version(np.__version__) < parse_version('1.13'),
+            "Prior to 1.13, numpy low level iterators didn't support removing "
+            "empty axis. So gufunc couldn't be called with empty inner loop")
+    def test_lu_m_and_n_zero(self):
+        """Corner case of decomposing where m = 0 and n = 0"""
+        a = np.ascontiguousarray(np.random.randn(0, 0))
+        p, l, u = gulinalg.lu(a)
+        # p is MxM, l is MxK, u is KxN where K = min(M, N)
+        # As M = 0 here, all three of them should be empty.
+        assert p.shape == (0, 0)
+        assert l.shape == (0, 0)
+        assert u.shape == (0, 0)
+        assert_allclose(np.dot(np.dot(p, l), u), a)
+
+    @skipIf(parse_version(np.__version__) < parse_version('1.13'),
+            "Prior to 1.13, numpy low level iterators didn't support removing "
+            "empty axis. So gufunc couldn't be called with empty inner loop")
+    def test_lu_m_zero(self):
+        """Corner case of decomposing where m = 0"""
+        a = np.ascontiguousarray(np.random.randn(0, 2))
+        p, l, u = gulinalg.lu(a)
+        # p is MxM, l is MxK, u is KxN where K = min(M, N)
+        # As M = 0 here, all three of them should be empty.
+        assert p.shape == (0, 0)
+        assert l.shape == (0, 0)
+        assert u.shape == (0, 2)
+        assert_allclose(np.dot(np.dot(p, l), u), a)
+
+    @skipIf(parse_version(np.__version__) < parse_version('1.13'),
+            "Prior to 1.13, numpy low level iterators didn't support removing "
+            "empty axis. So gufunc couldn't be called with empty inner loop")
+    def test_lu_n_zero(self):
+        """Corner case of decomposing where n = 0"""
+        a = np.ascontiguousarray(np.random.randn(2, 0))
+        p, l, u = gulinalg.lu(a)
+        # p is MxM, l is MxK, u is KxN where K = min(M, N)
+        # As N = 0 here, assert following dimensions.
+        assert p.shape == (2, 2)
+        assert l.shape == (2, 0)
+        assert u.shape == (0, 0)
+        assert_allclose(np.dot(np.dot(p, l), u), a)
+
+    def test_lu_size_one_matrix(self):
         """Corner case of decomposing size 1 matrix"""
         a = np.ascontiguousarray(np.random.randn(1, 1))
         p, l, u = gulinalg.lu(a)
@@ -70,6 +113,62 @@ class TestLU(TestCase):
     def test_vector(self):
         """test vectorized LU decomposition"""
         a = np.ascontiguousarray(np.random.randn(10, 75, 50))
+        p, l, u = gulinalg.lu(a)
+        res = np.stack([np.dot(np.dot(p[i], l[i]), u[i])
+                        for i in range(len(a))])
+        assert_allclose(res, a)
+
+    @skipIf(parse_version(np.__version__) < parse_version('1.13'),
+            "Prior to 1.13, numpy low level iterators didn't support removing "
+            "empty axis. So gufunc couldn't be called with empty inner loop")
+    def test_vector_m_and_n_zero(self):
+        """Corner case of decomposing where m = 0 and n = 0"""
+        a = np.ascontiguousarray(np.random.randn(10, 0, 0))
+        p, l, u = gulinalg.lu(a)
+        # p is MxM, l is MxK, u is KxN where K = min(M, N)
+        # As M = 0 here, all three of them should be empty.
+        assert p.shape == (10, 0, 0)
+        assert l.shape == (10, 0, 0)
+        assert u.shape == (10, 0, 0)
+        res = np.stack([np.dot(np.dot(p[i], l[i]), u[i])
+                        for i in range(len(a))])
+        assert_allclose(res, a)
+
+    @skipIf(parse_version(np.__version__) < parse_version('1.13'),
+            "Prior to 1.13, numpy low level iterators didn't support removing "
+            "empty axis. So gufunc couldn't be called with empty inner loop")
+    def test_vector_m_zero(self):
+        """Corner case of decomposing where m = 0"""
+        a = np.ascontiguousarray(np.random.randn(10, 0, 2))
+        p, l, u = gulinalg.lu(a)
+        # p is MxM, l is MxK, u is KxN where K = min(M, N)
+        # As M = 0 here, all three of them should be empty.
+        assert p.shape == (10, 0, 0)
+        assert l.shape == (10, 0, 0)
+        assert u.shape == (10, 0, 2)
+        res = np.stack([np.dot(np.dot(p[i], l[i]), u[i])
+                        for i in range(len(a))])
+        assert_allclose(res, a)
+
+    @skipIf(parse_version(np.__version__) < parse_version('1.13'),
+            "Prior to 1.13, numpy low level iterators didn't support removing "
+            "empty axis. So gufunc couldn't be called with empty inner loop")
+    def test_vector_n_zero(self):
+        """Corner case of decomposing where n = 0"""
+        a = np.ascontiguousarray(np.random.randn(10, 2, 0))
+        p, l, u = gulinalg.lu(a)
+        # p is MxM, l is MxK, u is KxN where K = min(M, N)
+        # As N = 0 here, assert following dimensions.
+        assert p.shape == (10, 2, 2)
+        assert l.shape == (10, 2, 0)
+        assert u.shape == (10, 0, 0)
+        res = np.stack([np.dot(np.dot(p[i], l[i]), u[i])
+                        for i in range(len(a))])
+        assert_allclose(res, a)
+
+    def test_vector_size_one_matrix(self):
+        """Corner case of decomposing size 1 matrix"""
+        a = np.ascontiguousarray(np.random.randn(10, 1, 1))
         p, l, u = gulinalg.lu(a)
         res = np.stack([np.dot(np.dot(p[i], l[i]), u[i])
                         for i in range(len(a))])
@@ -134,7 +233,46 @@ class TestQR(TestCase):
         assert r.shape == (n, n)
         assert_allclose(np.dot(q, r), a)
 
-    def test_qr_size_1_matrix(self):
+    @skipIf(parse_version(np.__version__) < parse_version('1.13'),
+            "Prior to 1.13, numpy low level iterators didn't support removing "
+            "empty axis. So gufunc couldn't be called with empty inner loop")
+    def test_m_and_n_zero(self):
+        """Corner case of decomposing where m = 0 and n = 0"""
+        a = np.ascontiguousarray(np.random.randn(0, 0))
+        q, r = gulinalg.qr(a)
+        # q is MxM or MxK (economy mode) and r is MxN or KxN (economy mode)
+        # where K = min(M, N). As M = 0, K = 0. so q and r should be empty.
+        assert q.shape == (0, 0)
+        assert r.shape == (0, 0)
+        assert_allclose(np.dot(q, r), a)
+
+    @skipIf(parse_version(np.__version__) < parse_version('1.13'),
+            "Prior to 1.13, numpy low level iterators didn't support removing "
+            "empty axis. So gufunc couldn't be called with empty inner loop")
+    def test_m_zero(self):
+        """Corner case of decomposing where m = 0"""
+        a = np.ascontiguousarray(np.random.randn(0, 2))
+        q, r = gulinalg.qr(a)
+        # q is MxM or MxK (economy mode) and r is MxN or KxN (economy mode)
+        # where K = min(M, N).
+        assert q.shape == (0, 0)
+        assert r.shape == (0, 2)
+        assert_allclose(np.dot(q, r), a)
+
+    @skipIf(parse_version(np.__version__) < parse_version('1.13'),
+            "Prior to 1.13, numpy low level iterators didn't support removing "
+            "empty axis. So gufunc couldn't be called with empty inner loop")
+    def test_n_zero(self):
+        """Corner case of decomposing where n = 0"""
+        a = np.ascontiguousarray(np.random.randn(2, 0))
+        q, r = gulinalg.qr(a)
+        # q is MxM or MxK (economy mode) and r is MxN or KxN (economy mode)
+        # where K = min(M, N).
+        assert q.shape == (2, 2)
+        assert r.shape == (2, 0)
+        assert_allclose(np.dot(q, r), a)
+
+    def test_qr_size_one_matrix(self):
         """Corner case of decomposing size 1 matrix"""
         m = 1
         n = 1
@@ -175,6 +313,59 @@ class TestQR(TestCase):
         """test vectorized QR decomposition"""
         a = np.ascontiguousarray(np.random.randn(10, 75, 50))
         q, r = gulinalg.qr(a)
+        res = np.stack([np.dot(q[i], r[i]) for i in range(len(a))])
+        assert_allclose(res, a)
+
+    @skipIf(parse_version(np.__version__) < parse_version('1.13'),
+            "Prior to 1.13, numpy low level iterators didn't support removing "
+            "empty axis. So gufunc couldn't be called with empty inner loop")
+    def test_vector_m_and_n_zero(self):
+        """Corner case of decomposing where m = 0 and n = 0"""
+        a = np.ascontiguousarray(np.random.randn(10, 0, 0))
+        q, r = gulinalg.qr(a)
+        # q is MxM or MxK (economy mode) and r is MxN or KxN (economy mode)
+        # where K = min(M, N). As M = 0, K = 0. so q and r should be empty.
+        assert q.shape == (10, 0, 0)
+        assert r.shape == (10, 0, 0)
+        res = np.stack([np.dot(q[i], r[i]) for i in range(len(a))])
+        assert_allclose(res, a)
+
+    @skipIf(parse_version(np.__version__) < parse_version('1.13'),
+            "Prior to 1.13, numpy low level iterators didn't support removing "
+            "empty axis. So gufunc couldn't be called with empty inner loop")
+    def test_vector_m_zero(self):
+        """Corner case of decomposing where m = 0"""
+        a = np.ascontiguousarray(np.random.randn(10, 0, 2))
+        q, r = gulinalg.qr(a)
+        # q is MxM or MxK (economy mode) and r is MxN or KxN (economy mode)
+        # where K = min(M, N).
+        assert q.shape == (10, 0, 0)
+        assert r.shape == (10, 0, 2)
+        res = np.stack([np.dot(q[i], r[i]) for i in range(len(a))])
+        assert_allclose(res, a)
+
+    @skipIf(parse_version(np.__version__) < parse_version('1.13'),
+            "Prior to 1.13, numpy low level iterators didn't support removing "
+            "empty axis. So gufunc couldn't be called with empty inner loop")
+    def test_vector_n_zero(self):
+        """Corner case of decomposing where n = 0"""
+        a = np.ascontiguousarray(np.random.randn(10, 2, 0))
+        q, r = gulinalg.qr(a)
+        # q is MxM or MxK (economy mode) and r is MxN or KxN (economy mode)
+        # where K = min(M, N).
+        assert q.shape == (10, 2, 2)
+        assert r.shape == (10, 2, 0)
+        res = np.stack([np.dot(q[i], r[i]) for i in range(len(a))])
+        assert_allclose(res, a)
+
+    def test_vector_size_one_matrices(self):
+        """Corner case of decomposing where m = 1 and n = 1"""
+        a = np.ascontiguousarray(np.random.randn(10, 1, 1))
+        q, r = gulinalg.qr(a)
+        # q is MxM or MxK (economy mode) and r is MxN or KxN (economy mode)
+        # where K = min(M, N). As M = 0, K = 0. so q and r should be empty.
+        assert q.shape == (10, 1, 1)
+        assert r.shape == (10, 1, 1)
         res = np.stack([np.dot(q[i], r[i]) for i in range(len(a))])
         assert_allclose(res, a)
 


### PR DESCRIPTION
If size of a vector is 1 (or matrix is 1x1), gufunc won't step
along that dimension. The stride will be 0 for that.
Underlying functions expect positive step, this change
handles that. Change also handles cases where underlying function
throws errors such as:
'Intel MKL ERROR: Parameter 4 was incorrect on entry to DGETRF'